### PR TITLE
修正因路径导致linux下无法正确执行程序的问题

### DIFF
--- a/src/App/App.php
+++ b/src/App/App.php
@@ -203,8 +203,8 @@ class App
             define('MODULE_NAME', strip_tags($module));
 
             // 模块初始化
-            if (MODULE_NAME && !in_array(MODULE_NAME, $config['deny_module_list']) && is_dir(APP_PATH . MODULE_NAME)) {
-                define('MODULE_PATH', APP_PATH . MODULE_NAME . DS);
+            if (MODULE_NAME && !in_array(MODULE_NAME, $config['deny_module_list']) && is_dir(APP_PATH . Loader::parseName( MODULE_NAME,1))) {
+                define('MODULE_PATH', APP_PATH . Loader::parseName(MODULE_NAME,1) . DS);
                 define('VIEW_PATH', MODULE_PATH . VIEW_LAYER . DS);
                 // 初始化模块
                 self::initModule(MODULE_NAME, $config);

--- a/src/ClassLoader/Loader.php
+++ b/src/ClassLoader/Loader.php
@@ -351,7 +351,7 @@ class Loader
         } else {
             $module = APP_MULTI_MODULE ? MODULE_NAME : '';
         }
-        $class = self::parseClass(self::parseName($module, 1), self::parseName($layer, 1), $name);
+        $class = self::parseClass($module, $layer, $name);
         if (class_exists($class)) {
             $action = new $class();
             $_instance[$name . $layer] = $action;
@@ -491,6 +491,8 @@ class Loader
      */
     public static function parseClass($module, $layer, $name)
     {
+        $module=self::parseName($module,1);
+        $layer=self::parseName($layer,1);
         $name  = str_replace(['/', '.'], '\\', $name);
         $array = explode('\\', $name);
         $class = self::parseName(array_pop($array), 1) . (CLASS_APPEND_SUFFIX ? ucfirst($layer) : '');


### PR DESCRIPTION
1/修复  强制模块名小写导致模块在linux平台下模块路径有误
2/修复  因某些原因导致空控制器在linux平台下控制器路径有误